### PR TITLE
[Update] setting notification name

### DIFF
--- a/app/src/main/java/io/github/kurramkurram/angerlog/ui/screen/setting/SettingScreen.kt
+++ b/app/src/main/java/io/github/kurramkurram/angerlog/ui/screen/setting/SettingScreen.kt
@@ -124,16 +124,6 @@ fun SettingScreen(
                 leading = stringResource(R.string.setting_news),
                 badge = badge,
             ) { onNewsClick() }
-
-            // 通知設定
-            SettingScreenItem(
-                leading = stringResource(R.string.setting_notification),
-                iconType = SettingLeadingIconType.OpenInNew,
-            ) {
-                startNotificationSetting(
-                    context,
-                )
-            }
         }
 
         SettingScreenSectionItem {
@@ -163,6 +153,18 @@ fun SettingScreen(
             // アプリを評価する
             SettingScreenItem(leading = stringResource(R.string.setting_evaluate)) {
                 startReview(
+                    context,
+                )
+            }
+        }
+
+        SettingScreenSectionItem {
+            // 通知設定
+            SettingScreenItem(
+                leading = stringResource(R.string.setting_notification),
+                iconType = SettingLeadingIconType.OpenInNew,
+            ) {
+                startNotificationSetting(
                     context,
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,13 +64,13 @@
     <string name="setting_about_app">%sについて</string>
     <string name="setting_tips">お役立ちTips</string>
     <string name="setting_news">お知らせ</string>
-    <string name="setting_notification">お知らせの設定</string>
     <string name="setting_application_version">アプリバージョン</string>
     <string name="setting_policy">利用規約</string>
     <string name="setting_License">ライセンス</string>
     <string name="setting_share">このアプリをシェアする</string>
     <string name="setting_other_app">ほかのアプリ</string>
     <string name="setting_evaluate">このアプリを評価する</string>
+    <string name="setting_notification">通知の設定</string>
     <string name="setting_question">問い合わせはこちら</string>
     <string name="setting_question_mail_subject">%sに関する問い合わせ</string>
     <string name="setting_question_text">アプリバージョン：%1s\nOSバージョン：Android %2d \n 機種名：%3s\n日にち：%4s</string>


### PR DESCRIPTION
## 概要
<!-- このPRの概要 -->
設定の「お知らせの設定」を「通知の設定」に変更


## やったこと
<!-- このPRでできるようになったこと --> 
- 設定の「お知らせの設定」を「通知の設定」に変更
- 「通知の設定」を「問い合わせ」の上に移動（現時点では機能もなくあまり使わない想定なので）

## やらないこと
<!-- このPRではやらないこと --> 
ー
## 動作確認
<!-- 行った動作確認 -->
やったことが行えること

<!-- 関連するissueは右のDevelopmentで紐づける -->
