### PR TITLE
[Update] Widget receiver exported false

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
         <receiver
             android:name=".RegisterWidgetReceiver"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>


### PR DESCRIPTION
## 概要
<!-- このPRの概要 -->
ウィジェット用のBroadcastReceiverを非公開にした

## やったこと
<!-- このPRでできるようになったこと --> 
ウィジェット用のBroadcastReceiverを非公開にした。
システムから通知されるReceiverのため公開する必要がないと考えられる。

## やらないこと
<!-- このPRではやらないこと --> 
ー

## 動作確認
<!-- 行った動作確認 -->
ウィジェットを追加・ウィジェットからアプリが起動できることを確認

<!-- 関連するissueは右のDevelopmentで紐づける -->
